### PR TITLE
cloudstack: enable tag values with colon

### DIFF
--- a/hm/managers/cloudstack.py
+++ b/hm/managers/cloudstack.py
@@ -63,7 +63,7 @@ class CloudStackManager(managers.BaseManager):
         tag_del_count = 0
         for tag in tag_list:
             ignore_tag_key = False
-            parts = tag.split(":", 2)
+            parts = tag.split(":", 1)
             if len(parts) < 2:
                 continue
             key, value = parts

--- a/tests/managers/test_cloudstack_manager.py
+++ b/tests/managers/test_cloudstack_manager.py
@@ -91,7 +91,7 @@ class CloudStackManagerTestCase(unittest.TestCase):
             "CLOUDSTACK_PROJECT_ID": "project-123",
             "CLOUDSTACK_NETWORK_IDS": "net-123",
             "CLOUDSTACK_GROUP": "feaas",
-            "HOST_TAGS": "Name:something,monitor:1,wait=wat",
+            "HOST_TAGS": "Name:something,monitor:1,wait=wat,syslog:logging:5140",
         })
 
         client_mock = mock.Mock()
@@ -125,6 +125,8 @@ class CloudStackManagerTestCase(unittest.TestCase):
             "tags[0].value": "something",
             "tags[1].key": "monitor",
             "tags[1].value": "1",
+            "tags[2].key": "syslog",
+            "tags[2].value": "logging:5140",
         }
         client_mock.createTags.assert_called_with(tag_data)
 


### PR DESCRIPTION
It enables tag values with colon. Instead we would have an error ValueError: too many values to unpack